### PR TITLE
Fix server start error handling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,6 +61,5 @@ func run() error {
 	}))
 	e.Use(middleware.Recover())
 
-	e.Start(fmt.Sprintf(":%d", 5001))
-	return nil
+	return e.Start(fmt.Sprintf(":%d", 5001))
 }


### PR DESCRIPTION
## Summary
- ensure the API server returns any startup error

## Testing
- `go vet ./...` *(fails: Forbidden module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_6840512bc9d0832eae813bfa340f9064